### PR TITLE
Fix build issues on OS X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/) princip
 
 ## [Unreleased]
 
+### Fixed
+- `MAP_ANONYMOUS` undefined on OS X
+- pthread spinlocks unavailable on OS X
+
 ## [0.5.1] - 2016-05-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cd handlebars.c
 
 ```bash
 # Install dependencies
-brew install autoconf automake bison flex gcc json-c libtool libyaml pkg-config talloc
+brew install autoconf automake bison flex gcc json-c libtool libyaml lmdb pkg-config talloc
 
 # Install testing dependencies
 brew install check lcov pcre


### PR DESCRIPTION
- `MAP_ANONYMOUS` is not defined
- pthread spinlocks are not available
- lmdb is required to pass all unit tests
