### PR TITLE
Fix Wformat-security for libcheck 0.15.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,8 @@
     sha256 = "0c4f0aydy5ni3skbyvsrg6yskvljmsrqhhpx54lk0jlwblqziah4";
   }))) {},
 
+  check ? pkgs.callPackage ./nix/check.nix {},
+
   checkSupport ? true,
   cmakeSupport ? false,
   debugSupport ? false,
@@ -45,7 +47,7 @@
 }:
 
 pkgs.callPackage ./nix/derivation.nix {
-  inherit stdenv;
+  inherit stdenv check;
   inherit handlebarscVersion handlebarscSrc handlebarscSha256;
   inherit mustache_spec handlebars_spec;
   inherit checkSupport cmakeSupport debugSupport devSupport doxygenSupport hardeningSupport jsonSupport lmdbSupport ltoSupport noRefcountingSupport pthreadSupport sharedSupport staticSupport WerrorSupport valgrindSupport yamlSupport;

--- a/nix/check.nix
+++ b/nix/check.nix
@@ -1,0 +1,36 @@
+{ fetchurl, stdenv
+, CoreServices ? null
+}:
+
+stdenv.mkDerivation rec {
+  pname = "check";
+  version = "0.15.2";
+
+  src = fetchurl {
+    url = "https://github.com/libcheck/check/releases/download/${version}/check-${version}.tar.gz";
+    sha256 = "02m25y9m46pb6n46s51av62kpd936lkfv3b13kfpckgvmh5lxpm8";
+  };
+
+  # Test can randomly fail: https://hydra.nixos.org/build/7243912
+  doCheck = false;
+
+  buildInputs = stdenv.lib.optional stdenv.isDarwin CoreServices;
+
+  meta = with stdenv.lib; {
+    description = "Unit testing framework for C";
+
+    longDescription =
+      '' Check is a unit testing framework for C.  It features a simple
+         interface for defining unit tests, putting little in the way of the
+         developer.  Tests are run in a separate address space, so Check can
+         catch both assertion failures and code errors that cause
+         segmentation faults or other signals.  The output from unit tests
+         can be used within source code editors and IDEs.
+      '';
+
+    homepage = "https://libcheck.github.io/check/";
+
+    license = licenses.lgpl2Plus;
+    platforms = platforms.all;
+  };
+}

--- a/nix/ci.nix
+++ b/nix/ci.nix
@@ -3,6 +3,7 @@ let
     pkgs.callPackage ../default.nix (args // {
       inherit stdenv;
       WerrorSupport = true;
+      check = pkgs.callPackage ./check.nix {};
     });
 
   generateHandlebarsCTestsForPlatform2 = { pkgs, ... }@args:

--- a/tests/test_json.c
+++ b/tests/test_json.c
@@ -279,7 +279,7 @@ START_TEST(test_parse_error_json)
     if( handlebars_setjmp_ex(context, &buf) ) {
         char * error = NULL;
         if( 0 != regex_compare("^JSON Parse error", handlebars_error_msg(context), &error) ) {
-            ck_abort_msg(error);
+            ck_abort_msg("%s", error);
         }
         return;
     }

--- a/tests/test_partial_loader.c
+++ b/tests/test_partial_loader.c
@@ -53,14 +53,14 @@ static struct handlebars_string * execute_template(const char *template)
     // Check error
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
         // @todo maybe check message
-        ck_abort_msg(handlebars_error_msg(context));
+        ck_abort_msg("%s", handlebars_error_msg(context));
         return NULL;
     }
 
     // Compile
     struct handlebars_program * program = handlebars_compiler_compile_ex(compiler, ast);
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
-        ck_abort_msg(handlebars_error_msg(context));
+        ck_abort_msg("%s", handlebars_error_msg(context));
         return NULL;
     }
 
@@ -97,7 +97,7 @@ static struct handlebars_string * execute_template(const char *template)
     // Execute
     struct handlebars_string * buffer = handlebars_vm_execute(vm, module, input);
 
-    ck_assert_msg(handlebars_error_msg(HBSCTX(vm)) == NULL, handlebars_error_msg(HBSCTX(vm)));
+    ck_assert_msg(handlebars_error_msg(HBSCTX(vm)) == NULL, "%s", handlebars_error_msg(HBSCTX(vm)));
 
     // Test iterator/count
     ck_assert_int_eq(1, handlebars_value_count(partials));

--- a/tests/test_spec_handlebars.c
+++ b/tests/test_spec_handlebars.c
@@ -357,7 +357,7 @@ START_TEST(test_ast_to_string_on_handlebars_spec)
 
     // Check error
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
-        ck_assert_msg(0, handlebars_error_msg(context));
+        ck_assert_msg(0, "%s", handlebars_error_msg(context));
     }
 
     ast_str = handlebars_ast_to_string(context, ast);
@@ -376,7 +376,7 @@ START_TEST(test_ast_to_string_on_handlebars_spec)
             expected,
             actual
         );
-        ck_abort_msg(tmp);
+        ck_abort_msg("%s", tmp);
     }
 }
 END_TEST
@@ -445,7 +445,7 @@ static inline void run_test(struct generic_test * test, int _i)
     // Check error
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
         // @todo maybe check message
-        ck_assert_msg(test->exception, handlebars_error_msg(context));
+        ck_assert_msg(test->exception, "%s", handlebars_error_msg(context));
         return;
     }
 
@@ -534,14 +534,14 @@ static inline void run_test(struct generic_test * test, int _i)
             if( 0 == regex_compare(tmp, handlebars_error_msg(HBSCTX(vm)), &regex_error) ) {
                 // ok
             } else {
-                ck_assert_msg(0, regex_error);
+                ck_assert_msg(0, "%s", regex_error);
             }
             free(tmp);
         } else {
             ck_assert_str_eq(test->exceptionMatcher, handlebars_error_msg(HBSCTX(vm)));
         }
     } else {
-        ck_assert_msg(handlebars_error_msg(HBSCTX(vm)) == NULL, handlebars_error_msg(HBSCTX(vm)));
+        ck_assert_msg(handlebars_error_msg(HBSCTX(vm)) == NULL, "%s", handlebars_error_msg(HBSCTX(vm)));
         ck_assert_ptr_ne(test->expected, NULL);
         ck_assert_ptr_ne(buffer, NULL);
 
@@ -551,7 +551,7 @@ static inline void run_test(struct generic_test * test, int _i)
                                                    "" /*test->suite_name*/,
                                                    test->description, test->it, test->flags,
                                                    test->tmpl, test->expected, hbs_str_val(buffer));
-            ck_abort_msg(tmp);
+            ck_abort_msg("%s", tmp);
         }
     }
 

--- a/tests/test_spec_handlebars_compiler.c
+++ b/tests/test_spec_handlebars_compiler.c
@@ -701,7 +701,7 @@ START_TEST(handlebars_spec_compiler)
                 test->suite_name,
                 test->description, test->it, test->flags,
                 test->tmpl, hbs_str_val(test->expected), hbs_str_val(actual));
-            ck_abort_msg(tmp);
+            ck_abort_msg("%s", tmp);
         }
     /* } */
 }

--- a/tests/test_spec_handlebars_parser.c
+++ b/tests/test_spec_handlebars_parser.c
@@ -218,7 +218,7 @@ START_TEST(handlebars_spec_parser)
                 if( 0 == regex_compare(tmp, errmsgjs, &regex_error) ) {
                     // ok
                 } else {
-                    ck_assert_msg(0, regex_error);
+                    ck_assert_msg(0, "%s", regex_error);
                 }
                 free(tmp);
             } else {
@@ -231,7 +231,7 @@ START_TEST(handlebars_spec_parser)
             lesigh = handlebars_talloc_strdup_append(lesigh, errmsg);
             lesigh = handlebars_talloc_strdup_append(lesigh, "\nTemplate: \n");
             lesigh = handlebars_talloc_strdup_append(lesigh, test->tmpl);
-            ck_assert_msg(0, lesigh);
+            ck_assert_msg(0, "%s", lesigh);
         }
     } else {
         struct handlebars_string * output = handlebars_ast_print(HBSCTX(parser), ast);
@@ -252,10 +252,10 @@ START_TEST(handlebars_spec_parser)
                 lesigh = handlebars_talloc_strdup_append(lesigh, hbs_str_val(output));
                 lesigh = handlebars_talloc_strdup_append(lesigh, "\nTemplate: \n");
                 lesigh = handlebars_talloc_strdup_append(lesigh, test->tmpl);
-                ck_assert_msg(0, lesigh);
+                ck_assert_msg(0, "%s", lesigh);
             }
         } else {
-            ck_assert_msg(0, test->message);
+            ck_assert_msg(0, "%s", test->message);
         }
 
         handlebars_talloc_free(output);

--- a/tests/test_spec_mustache.c
+++ b/tests/test_spec_mustache.c
@@ -220,7 +220,7 @@ START_TEST(test_ast_to_string_on_mustache_spec)
 
     // Check error
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
-        ck_assert_msg(0, handlebars_error_msg(context));
+        ck_assert_msg(0, "%s", handlebars_error_msg(context));
     }
 
     ast_str = handlebars_ast_to_string(context, ast);
@@ -240,7 +240,7 @@ START_TEST(test_ast_to_string_on_mustache_spec)
             expected,
             actual
         );
-        ck_abort_msg(tmp);
+        ck_abort_msg("%s", tmp);
     }
 
     handlebars_string_delref(origtmpl);
@@ -276,7 +276,7 @@ START_TEST(test_mustache_spec)
 
     // Check error
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
-        ck_assert_msg(0, handlebars_error_msg(context));
+        ck_assert_msg(0, "%s", handlebars_error_msg(context));
     }
 
     // Compile
@@ -284,7 +284,7 @@ START_TEST(test_mustache_spec)
     handlebars_compiler_compile(compiler, ast);
 
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
-        ck_assert_msg(0, handlebars_error_msg(context));
+        ck_assert_msg(0, "%s", handlebars_error_msg(context));
     }
 
     // Serialize
@@ -319,7 +319,7 @@ START_TEST(test_mustache_spec)
 
     // Check error
     if( handlebars_error_num(context) != HANDLEBARS_SUCCESS ) {
-        ck_assert_msg(0, handlebars_error_msg(context));
+        ck_assert_msg(0, "%s", handlebars_error_msg(context));
     }
 
     ck_assert_ptr_ne(buffer, NULL);
@@ -345,7 +345,7 @@ START_TEST(test_mustache_spec)
             test->expected,
             hbs_str_val(buffer)
         );
-        ck_abort_msg(tmp);
+        ck_abort_msg("%s", tmp);
     }
 
     // ugh

--- a/tests/test_yaml.c
+++ b/tests/test_yaml.c
@@ -102,7 +102,7 @@ START_TEST(test_parse_error_yaml)
     if( handlebars_setjmp_ex(context, &buf) ) {
         char * error = NULL;
         if( 0 != regex_compare("^YAML Parse Error", handlebars_error_msg(context), &error) ) {
-            ck_abort_msg(error);
+            ck_abort_msg("%s", error);
         }
         return;
     }


### PR DESCRIPTION
Based on patch: https://git.remirepo.net/cgit/rpms/lib/libhandlebars.git/plain/build.patch

Fixes #87